### PR TITLE
Fix time restriction running at wrong time

### DIFF
--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -120,8 +120,8 @@ const onSceneChange = async (controller, name, oldName) => {
 
 	if (!config.pauseNotify) {
 		let now = new Date();
-		// var minutes = now.getMinutes();
-		var hour = now.getHours();
+		// var minutes = now.getUTCMinutes();
+		var hour = now.getUTCHours();
 		//logger.log("scene change current time",hour,now);
 		//if ((hour >= 19 && minutes >= 30) || hour >= 20 || hour < 8){
 		if ( hour >= config.notifyHours.start && hour < config.notifyHours.end ) {
@@ -421,8 +421,8 @@ function checkTimeAccess(controller, userCommand, accessProfile, channel, messag
 		if (!hasAccess) {
 			//check time
 			let now = new Date();
-			// var minutes = now.getMinutes();
-			var hour = now.getHours();
+			// var minutes = now.getUTCMinutes();
+			var hour = now.getUTCHours();
 			// console.log("check time",now,hour,config.restrictedHours);
 			if (hour >= config.restrictedHours.start && hour < config.restrictedHours.end) {
 				//restricted time
@@ -1929,8 +1929,8 @@ async function switchToCustomCams(controller, channel, accessProfile, userComman
 				if (config.timeRestrictedScenes.includes(camName)) {
 					//check time
 					let now = new Date();
-					var minutes = now.getMinutes();
-					var hour = now.getHours();
+					var minutes = now.getUTCMinutes();
+					var hour = now.getUTCHours();
 					if (hour >= config.restrictedHours.start && hour < config.restrictedHours.end) {
 						//restricted time
 						hasAccess = false;

--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -2238,7 +2238,7 @@ async function setPTZRoamMode(controller, scene) {
 function runAtSpecificTimeOfDay(hour, minutes, func) {
 	const twentyFourHours = 86400000;
 	const now = new Date();
-	let eta_ms = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hour, minutes, 0, 0).getTime() - now;
+	let eta_ms = new Date(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), hour, minutes, 0, 0).getTime() - now;
 	if (eta_ms < 0) {
 		eta_ms += twentyFourHours;
 	}


### PR DESCRIPTION
Since notify and time restriction hours are configured as UTC hours, checks should use UTC hours to compare.