### PR TITLE
Add FOV to ptzgetinfo

### DIFF
--- a/src/connections/cameras.js
+++ b/src/connections/cameras.js
@@ -382,6 +382,29 @@ class Axis {
   }
 
   /**
+   * Get the current FOV of the camera 
+   * 
+   * @returns {Promise<{ hFOV: number, vFOV: number } | null>}
+   */
+  async getCameraFOV() {
+    // Get the raw FOV data
+    const resp = await this.#get("/axis-cgi/view/param.cgi?action=list&group=root.ImageSource.I0.HorizontalFOV,root.ImageSource.I0.VerticalFOV");
+    if (resp === null) return null;
+  
+    // Parse the data (<key>=<value>\r\n...)
+    const fov = {};
+    resp.replace(/\r/g, "").split('\n').forEach(line => {
+      const [key, value] = line.split('=');
+      if (key && value) {
+        fov[key.trim()] = parseFloat(value.trim());
+      }
+    });
+    const hFOV = fov['root.ImageSource.I0.HorizontalFOV'];
+    const vFOV = fov['root.ImageSource.I0.VerticalFOV'];
+    return { hFOV, vFOV };
+  }
+
+  /**
    * Get the current movement speed of the camera
    *
    * @returns {Promise<number | null>}

--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -759,8 +759,9 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 			break;
 		case "ptzgetinfo":
 			let cpos = await camera.getPosition();
+		    let fov = await camera.getCameraFOV();
 			if (cpos && cpos.pan != null) {
-				controller.connections.twitch.send(channel, `PTZ Info (${currentScene}): ${cpos.pan}p |${cpos.tilt}t |${cpos.zoom}z |af ${cpos.autofocus || "n/a"} |${cpos.focus || "n/a"}f`);
+			        controller.connections.twitch.send(channel, `PTZ Info (${currentScene}): ${cpos.pan}p | ${cpos.tilt}t | ${cpos.zoom}z | af ${cpos.autofocus || "n/a"} | ${cpos.focus || "n/a"}f | hFOV: ${fov.hFOV || "n/a"} | vFOV: ${fov.vFOV || "n/a"}`);
 			} else {
 				logger.log("Failed to get ptz position");
 			}


### PR DESCRIPTION
Add camera horizontal and vertical FOV data to the ptzgetinfo output.
 
*API endpoint will need testing against alveus camera models to ensure valid responses.
