### PR TITLE
Add ptzcenter and ptzareazoom

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -230,7 +230,7 @@ const commandPermissionsCamera = {
     commandAdmins: ["testadmincamera"],
     commandSuperUsers: ["testsupercamera", "ptzcontrol", "ptzoverride", "ptzclear"],
     commandMods: ["testmodcamera", "ptztracking", "ptzspeed", "ptzspin", "ptzirlight", "ptzwake"],
-    commandOperator: ["ptzhomeold","ptzseta","ptzgetinfo","ptzset", "ptzpan", "ptztilt", "ptzmove", "ptzir", "ptzdry", "ptzfov", "ptzstop", "ptzsave", "ptzremove", "ptzrename"],
+    commandOperator: ["ptzhomeold","ptzseta","ptzgetinfo","ptzset", "ptzpan", "ptztilt", "ptzmove", "ptzir", "ptzdry", "ptzfov", "ptzstop", "ptzsave", "ptzremove", "ptzrename", "ptzcenter", "ptzareazoom"],
     commandVips: ["ptzhome", "ptzpreset", "ptzzoom", "ptzload", "ptzlist", "ptzroam", "ptzroaminfo", "ptzfocus", "ptzgetfocus", "ptzfocusr", "ptzautofocus"],
     commandUsers: []
 }

--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -723,6 +723,14 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 			camera.setSpeed(arg1);
 			controller.connections.database[currentScene].speed = arg1;
 			break;
+		case "ptzcenter":
+			//x-cord y-cord rzoom 
+			camera.ptz({ center: `${arg1},${arg2}`, rzoom: arg3 });
+			break;
+		case "ptzareazoom":
+			//x-cord y-cord zoom 
+			camera.ptz({ areazoom: `${arg1},${arg2},${arg3}` });
+			break;
 		case "ptzset":
 			//pan tilt zoom relative pos
 			camera.ptz({ rpan: arg1, rtilt: arg2, rzoom: arg3 * 100, autofocus: "on" });


### PR DESCRIPTION
Add ptzcenter and ptzareazoom commands.

Per API docs:

center= int,int - Center the camera on positions x,y where x,y are pixel coordinates in the client video stream.

areazoom= int,int,int - Centers on positions x,y (like the center command) and zooms by a factor of z/100. If z is more than 100 the image is zoomed in (for example; z=300 zooms in to 1/3 of the current field of view). If z is less than 100 the image is zoomed out (for example; z=50 zooms out to twice the current field of view).

This should allow for moving the camera by providing pixel coordinates (click coordinates) instead of pan / tilt angles (which requires FOV calculations).