### PR TITLE
Add "scenecams" command

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -244,7 +244,7 @@ const commandPermissionsExtra = {
     commandMods: ["testmodextra", "resetsource","resetsourcef","camload", "camlist", "camsave", "camrename", "campresetremove", "customcams", "customcamsbig", "customcamstl", "customcamstr", "customcamsbl", "customcamsbr",
         "unmutecam", "unmuteallcams", "nightcams", "nightcamsbig", "indoorcams", "addcam"],
     commandOperator: [],
-    commandVips: ["getvolume", "setvolume", "resetvolume", "removecam","swapcam", "mutecam", "muteallcams", "musicvolume", "musicnext", "musicprev", "mutemusic", "unmutemusic", "mutemusiclocal", "unmutemusiclocal", "resetbackpack", "resetpc", "resetlivecam", "resetbackpackf", "resetpcf", "resetlivecamf", "resetcam", "resetextra","resetphone", "resetphonef"],
+    commandVips: ["getvolume", "setvolume", "resetvolume", "removecam", "swapcam", "scenecams", "mutecam", "muteallcams", "musicvolume", "musicnext", "musicprev", "mutemusic", "unmutemusic", "mutemusiclocal", "unmutemusiclocal", "resetbackpack", "resetpc", "resetlivecam", "resetbackpackf", "resetpcf", "resetlivecamf", "resetcam", "resetextra","resetphone", "resetphonef"],
     commandUsers: []
 }
 timeRestrictedCommands = timeRestrictedCommands.concat(["unmutecam", "unmuteallcams"]);

--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -1488,6 +1488,31 @@ async function checkExtraCommand(controller, userCommand, accessProfile, channel
 				switchToCustomCams(controller, channel, accessProfile, userCommand, fullArgs);
 			}
 			break;
+		case "scenecams":
+			if (currentScene != "custom") {
+				return false;
+			}
+
+			let output = "";
+			if (arg1 == "json") {
+				output = JSON.stringify(currentCamList);
+			} else if (arg1 == "jsonmap") {
+				const jsonobj = {};
+				for (let i = 0; i < currentCamList.length; i++) {
+					jsonobj[i + 1] = currentCamList[i];
+				}
+				output = JSON.stringify(jsonobj);
+			} else {
+				for (let i = 0; i < currentCamList.length; i++) {
+					output = `${output}${i + 1}: ${currentCamList[i]}, `;
+					if (i != currentCamList.length - 1) {
+						output = `${output}, `;
+					}
+				}
+			}
+
+			controller.connections.twitch.send(channel, output)
+			break;
 		case "swapcam":
 			if (currentScene != "custom") {
 				return false;

--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -1504,7 +1504,7 @@ async function checkExtraCommand(controller, userCommand, accessProfile, channel
 				output = JSON.stringify(jsonobj);
 			} else {
 				for (let i = 0; i < currentCamList.length; i++) {
-					output = `${output}${i + 1}: ${currentCamList[i]}, `;
+					output = `${output}${i + 1}: ${currentCamList[i]}`;
 					if (i != currentCamList.length - 1) {
 						output = `${output}, `;
 					}


### PR DESCRIPTION
This PR adds a simple command that (hopefully) lists the cams in the scene along with their index in a few different formats. The intent is to be used alongside the `ptzcenter` and `ptzareazoom` commands, allowing any cam to be clicked on without having to select the one to be acted on in advance. Two JSON formats can be returned (one as an array and one as an object) for easier programmatic access as well as a default formatted output just for information.