### PR TITLE
!ptzclick Command

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -230,7 +230,7 @@ const commandPermissionsCamera = {
     commandAdmins: ["testadmincamera"],
     commandSuperUsers: ["testsupercamera", "ptzcontrol", "ptzoverride", "ptzclear"],
     commandMods: ["testmodcamera", "ptztracking", "ptzspeed", "ptzspin", "ptzirlight", "ptzwake"],
-    commandOperator: ["ptzhomeold","ptzseta","ptzgetinfo","ptzset", "ptzpan", "ptztilt", "ptzmove", "ptzir", "ptzdry", "ptzfov", "ptzstop", "ptzsave", "ptzremove", "ptzrename", "ptzcenter", "ptzareazoom"],
+    commandOperator: ["ptzhomeold","ptzseta","ptzgetinfo","ptzset", "ptzpan", "ptztilt", "ptzmove", "ptzir", "ptzdry", "ptzfov", "ptzstop", "ptzsave", "ptzremove", "ptzrename", "ptzcenter", "ptzareazoom", "ptzclick"],
     commandVips: ["ptzhome", "ptzpreset", "ptzzoom", "ptzload", "ptzlist", "ptzroam", "ptzroaminfo", "ptzfocus", "ptzgetfocus", "ptzfocusr", "ptzautofocus"],
     commandUsers: []
 }

--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -770,7 +770,7 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 			let y = 540
 			for (let i = 0; i < zones.length; i++) {
 			z = zones[i]
-				if (x_unscaled > z.min_x && x_unscaled < z.max_x && y_unscaled > z.min_y && y_unscaled < z.max_y) {
+				if (x_unscaled >= z.min_x && x_unscaled < z.max_x && y_unscaled >= z.min_y && y_unscaled < z.max_y) {
 					zone = z.zone
 					x = (x_unscaled - z.offset_x) * z.scale_x
 					y = (y_unscaled - z.offset_y) * z.scale_y

--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -763,6 +763,10 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 				{ min_x: x2, max_x: width, min_y: y2, max_y: height, scale_x: 3, scale_y: 3, offset_x: x2, offset_y: y2, zone: 6 }
 			];
 
+			// Defaults to the center of the screen, although it should never matter
+			let zone = -1
+			let x = 960
+			let y = 540
 			for (let i = 0; i < zones.length; i++) {
 			z = zones[i]
 				if (x_unscaled > z.min_x && x_unscaled < z.max_x && y_unscaled > z.min_y && y_unscaled < z.max_y) {
@@ -771,6 +775,11 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 					y = (y_unscaled - z.offset_y) * z.scale_y
 					break
 				}
+			}
+
+			// if invalid coordinates are given and no match is found, don't bother continuing
+			if (zone == -1) {
+				return false
 			}
 
 			camName = currentCamList[zone]

--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -788,14 +788,10 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 			if (camName == undefined) {
 				return false
 			}
+			
+			camera = controller.connections.cameras[camName]
 
-			ptzcamName = helper.cleanName(camName);
-			baseName = config.customCommandAlias[ptzcamName] ?? ptzcamName;
-			ptzcamName = config.axisCameraCommandMapping[baseName] ?? baseName;
-	
-			camera = controller.connections.cameras[ptzcamName]
-
-			camera.ptz({ areazoom: `${x},${y},${zoom}` });
+			camera.ptz({ areazoom: `${Math.round(x)},${Math.round(y)},${Math.round(zoom)}` });
 			break;
 		case "ptzset":
 			//pan tilt zoom relative pos

--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -783,7 +783,7 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 				return false
 			}
 
-			camName = currentCamList[zone]
+			camName = currentCamList[zone - 1]
 			// if there's no cam in the slot, return false
 			if (camName == undefined) {
 				return false

--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -784,7 +784,12 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 			}
 
 			camName = currentCamList[zone]
+			// if there's no cam in the slot, return false
+			if (camName == undefined) {
+				return false
+			}
 
+			undefined
 			ptzcamName = helper.cleanName(camName);
 			baseName = config.customCommandAlias[ptzcamName] ?? ptzcamName;
 			ptzcamName = config.axisCameraCommandMapping[baseName] ?? baseName;

--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -789,7 +789,6 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 				return false
 			}
 
-			undefined
 			ptzcamName = helper.cleanName(camName);
 			baseName = config.customCommandAlias[ptzcamName] ?? ptzcamName;
 			ptzcamName = config.axisCameraCommandMapping[baseName] ?? baseName;

--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -732,6 +732,7 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 			camera.ptz({ areazoom: `${arg1},${arg2},${arg3}` });
 			break;
 		case "ptzclick":
+			// Currently only works on the 6 cam scene, although this is easy to expand
 			if (currentScene != "custom") {
 				return false;
 			}


### PR DESCRIPTION
This is the first version of a generic ptzclick command, that takes any arbitrary coordinate pair and maps them to a local cam's coordinates, sending ptzareadraw to that cam with the scaled values. It currently only works on custom cams and with the 6 cam layout, although zones could be easily added or removed or even derived from a config. The current method of determining the bounds is based on a fixed number of zones dynamically created from the size of the video source (currently hardcoded to 1920x1080 because I don't know how to set the video parameters but its definitely possible from the obs bot). 

I am unsure if the portion of the code that changes the cam before sending the command works correctly, I don't really know how that part works. I figure space will have more insight into that.