### PR TITLE
Add continuouszoommove to ptzspin

### DIFF
--- a/src/connections/cameras.js
+++ b/src/connections/cameras.js
@@ -281,8 +281,8 @@ class Axis {
    * @param {number} tilt Tilt speed (-100 to 100)
    * @returns {Promise<boolean>}
    */
-  async continousPanTilt(pan, tilt) {
-    return this.ptz({ continuouspantiltmove: `${pan},${tilt}` });
+  async continousPanTilt(pan, tilt, zoom) {
+    return this.ptz({ continuouspantiltmove: `${pan},${tilt}`, continuouszoommove: `${zoom}` });
   }
 
   /**

--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -835,7 +835,7 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 			}
 			break;
 		case "ptzspin":
-			camera.continousPanTilt(arg1, arg2);
+			camera.continousPanTilt(arg1, arg2, arg3);
 			break;
 		case "ptzstop":
 			camera.continousPanTilt(0, 0);


### PR DESCRIPTION
Add continuouszoommove to the ptzspin command.

New syntax:
!ptzspin pan tilt zoom

API description for continuouszoommove:
Continuous zoom motion. Positive values mean zoom in and negative values mean zoom out. 0 means stop.