### PR TITLE
Add !ptzdraw Command

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -231,7 +231,7 @@ const commandPermissionsCamera = {
     commandSuperUsers: ["testsupercamera", "ptzcontrol", "ptzoverride", "ptzclear"],
     commandMods: ["testmodcamera", "ptztracking", "ptzirlight", "ptzwake"],
     commandOperator: ["ptzhomeold","ptzseta","ptzgetinfo","ptzset", "ptzpan", "ptztilt", "ptzmove", "ptzir", "ptzdry",
-                     "ptzfov", "ptzstop", "ptzsave", "ptzremove", "ptzrename", "ptzcenter", "ptzareazoom", "ptzclick",
+                     "ptzfov", "ptzstop", "ptzsave", "ptzremove", "ptzrename", "ptzcenter", "ptzareazoom", "ptzclick", "ptzdraw",
                      "ptzspeed", "ptzspin"],
     commandVips: ["ptzhome", "ptzpreset", "ptzzoom", "ptzload", "ptzlist", "ptzroam", "ptzroaminfo", "ptzfocus", "ptzgetfocus", "ptzfocusr", "ptzautofocus"],
     commandUsers: []

--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -747,10 +747,12 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 		case "ptzcenter":
 			//x-cord y-cord rzoom 
 			camera.ptz({ center: `${arg1},${arg2}`, rzoom: arg3 });
+			camera.enableAutoFocus();
 			break;
 		case "ptzareazoom":
 			//x-cord y-cord zoom 
 			camera.ptz({ areazoom: `${arg1},${arg2},${arg3}` });
+			camera.enableAutoFocus();
 			break;
 		case "ptzclick":
 			//x-cord y-cord zoom 
@@ -783,6 +785,7 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 			camera = controller.connections.cameras[ptzcamName]
 
 			camera.ptz({ areazoom: `${Math.round(x)},${Math.round(y)},${Math.round(zoom)}` });
+			camera.enableAutoFocus();
 			controller.connections.twitch.send(channel, `Clicked on ${ptzcamName}`);
 			break;
 		case "ptzdraw":
@@ -828,6 +831,7 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 			camera = controller.connections.cameras[ptzcamName]
 
 			camera.ptz({ areazoom: `${Math.round(xMid)},${Math.round(yMid)},${Math.round(zoom)}` });
+			camera.enableAutoFocus();
 			controller.connections.twitch.send(channel, `Drawn on ${ptzcamName}`);
 			break;
 		case "ptzset":

--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -806,8 +806,6 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 				return false
 			}
 
-			x = (x_unscaled - z.positionX) / z.scaleX;
-			y = (y_unscaled - z.positionY) / z.scaleY;
 			xMid = (xMid - z.positionX) / z.scaleX;
 			yMid = (yMid - z.positionY) / z.scaleY;
 			box_width = width_unscaled / z.scaleX;

--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -787,13 +787,19 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 			zone = -1;
 			x = 960;
 			y = 540;
+
+			// We want to select zone based on the midpoint of the rectangle, not the origin
+			xMid = x_unscaled + (width_unscaled / 2);
+			yMid = y_unscaled + (height_unscaled / 2);
 	
 			for (let i = 0; i < zones.length; i++) {
 				z = zones[i];
-				if ((x_unscaled >= z.positionX && x_unscaled < z.positionX + z.width) && (y_unscaled >= z.positionY && y_unscaled < z.positionY + z.height)) {
+				if ((xMid >= z.positionX && xMid < z.positionX + z.width) && (yMid >= z.positionY && yMid < z.positionY + z.height)) {
 					zone = i;
 					x = (x_unscaled - z.positionX) / z.scaleX;
 					y = (y_unscaled - z.positionY) / z.scaleY;
+					xMid = (xMid - z.positionX) / z.scaleX;
+					yMid = (yMid - z.positionY) / z.scaleY;
 					box_width = width_unscaled / z.scaleX;
 					box_height = height_unscaled / z.scaleY;
 					break;
@@ -803,9 +809,6 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 			zoomWidth = width / box_width 
 			zoomHeight = height / box_height 
 			zoom = Math.min(zoomWidth, zoomHeight) * 100;
-	
-			xMid = x + (box_width / 2);
-			yMid = y + (box_height / 2);
 
 			// if invalid coordinates are given and no match is found, don't bother continuing
 			if (zone == -1) {


### PR DESCRIPTION
This PR adds a `ptzdraw` command that is meant to assist with the rectangle selection drawing that we have been using to control the cams. This doesn't add any new functionality but removes the need to do the math twice while drawing rectangles, once locally to calculate the zoom and once on the server to figure out which cam is selected and where. The command takes 4 arguments representing a rectangle drawn over the stream, the X and Y values of the upper left corner and the width and height of the rectangle. The server then calculates the midpoint, the cam the midpoint lies in is selected, and then all values are scaled to that cams local values.

As with `ptzclick` the values sent as arguments are assumed to be from a 1920x1080 frame since the server has no way of knowing how large any given viewport is, so scaling from any client viewport to 1920x1080 will still need to be done clientside before calling this command with those values.

Additionally, it simplifies the code in `ptzclick` to use the configs instead of calculated values. This has the additional benefit of potentially making it work in any custom layout although this was not tested. It generally makes the code simpler and reuses existing constructs.

Finally, it adds a response to `click` and `draw` commands. Since these commands don't have a cam argument it is hard to tell what other cam ops are doing and makes easy to accidentally send commands on the same cam as someone else. Now the bot will respond to all `click` and `draw` commands with the targeted cam to make it more clear what is being done by looking at chat.