### PR TITLE
Fix ptzclick/draw slot1 error

### DIFF
--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -629,7 +629,7 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 	}
 
 	//cant find camera client
-	if (camera == null) {
+        if (camera == null && !(userCommand.includes("ptzdraw") || userCommand.includes("ptzclick"))) {
 		return false;
 	}
 


### PR DESCRIPTION
If a cam with no Axis mapping is in slot 1 (phone cam, rat cams, multi cams etc) then ptzclick does not work on any of the other cams.

Fix bypasses a return when camera = null if ptzclick or ptzdraw are in the userCommand.
