### PR TITLE
add continuous focus command and fix typo

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -244,7 +244,7 @@ const commandPermissionsCamera = {
     commandMods: ["testmodcamera", "ptztracking", "ptzirlight", "ptzwake"],
     commandOperator: ["ptzhomeold","ptzseta","ptzgetinfo","ptzset", "ptzpan", "ptztilt", "ptzmove", "ptzir", "ptzdry",
                      "ptzfov", "ptzstop", "ptzsave", "ptzremove", "ptzrename", "ptzcenter", "ptzareazoom", "ptzclick", "ptzdraw",
-                     "ptzspeed", "ptzspin"],
+                     "ptzspeed", "ptzspin", "ptzcfocus"],
     commandVips: ["ptzhome", "ptzpreset", "ptzzoom","ptzzoomr", "ptzload", "ptzlist", "ptzroam", "ptzroaminfo", "ptzfocus", "ptzgetfocus", "ptzfocusr", "ptzautofocus", "ptzgetcam"],
     commandUsers: []
 }

--- a/src/connections/cameras.js
+++ b/src/connections/cameras.js
@@ -273,15 +273,28 @@ class Axis {
   }
 
   /**
+   * Enable a continuous focus motion
+   *
+   * Set the focus speed to 0 to stop
+   *
+   * @param {number} focus Focus speed (-100 to 100)
+   * @returns {Promise<boolean>}
+   */
+  async continuousFocus(focus) {
+    return this.ptz({ continuousfocusmove: `${focus}` });
+  }
+
+  /**
    * Enable a continuous pan/tilt movement
    *
    * Set the pan/tilt speed to 0 to stop
    *
    * @param {number} pan Pan speed (-100 to 100)
    * @param {number} tilt Tilt speed (-100 to 100)
+   * @param {number} zoom Zoom speed (-100 to 100)
    * @returns {Promise<boolean>}
    */
-  async continousPanTilt(pan, tilt, zoom) {
+  async continuousPanTilt(pan, tilt, zoom) {
     return this.ptz({ continuouspantiltmove: `${pan},${tilt}`, continuouszoommove: `${zoom}` });
   }
 

--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -689,6 +689,9 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 				camera.focusCamera(fscaledAmount);
 			}
 			break;
+		case "ptzcfocus":
+			camera.continuousFocus(arg1);
+			break;
 		case "ptzautofocus":
 			if (arg1 == "1" || arg1 == "on" || arg1 == "yes") {
 				camera.enableAutoFocus();
@@ -845,10 +848,10 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 			}
 			break;
 		case "ptzspin":
-			camera.continousPanTilt(arg1, arg2, arg3);
+			camera.continuousPanTilt(arg1, arg2, arg3);
 			break;
 		case "ptzstop":
-			camera.continousPanTilt(0, 0);
+			camera.continuousPanTilt(0, 0, 0);
 			break;
 		case "ptzdry":
 			camera.speedDry();


### PR DESCRIPTION
Add !ptzcfocus command for continuous focus, similar concept to !ptzspin but for focus instead of pan/tilt/zoom.

Info on continuousfocusmove can be found here:
https://www.axis.com/vapix-library/subjects/t10175981/section/t10036011/display?section=t10036011-t10004639

I'd like to play around with this since I think it could be really useful for when the pollinator cam(s) are available.