### PR TITLE
allow resetcam to use cam aliases

### DIFF
--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -1480,6 +1480,7 @@ async function checkExtraCommand(controller, userCommand, accessProfile, channel
 		case "resetcam":
 			let camname = arg1Clean;
 			//remove possible cam wording
+			camname  = customCommandAlias[camname] || camname; // allow for cam name aliases
 			camname = "fullcam " + camname;
 			controller.connections.obs.local.restartSceneItem(controller.connections.obs.local.currentScene, camname);
 			break;


### PR DESCRIPTION
This should allow !resetcam to use any of the cam name aliases instead of needing to know the scene name.

i.e. marm should now work instead of needing to do marmoset, or wolfwolfin should work instead of needing to do wolfmulti2

The specific names will still work as well.