### PR TITLE
Adding ability to removecam and prevent mods from switching back

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -254,11 +254,11 @@ const commandPermissionsCamera = {
 //Extra Commands
 const commandPermissionsExtra = {
     commandAdmins: ["testadminextra"],
-    commandSuperUsers: ["testsuperextra", "resetcloudsource", "resetcloudsourcef", "setalveusscene", "setcloudscene", "changeserver", "setmute", "camclear"],
+    commandSuperUsers: ["testsuperextra", "resetcloudsource", "resetcloudsourcef", "setalveusscene", "setcloudscene", "changeserver", "setmute", "camclear", "setrestricted"],
     commandMods: ["testmodextra", "resetsource","resetsourcef","camload", "camlist", "camsave", "camrename", "campresetremove", "customcams", "customcamsbig", "customcamstl", "customcamstr", "customcamsbl", "customcamsbr",
-        "unmutecam", "unmuteallcams", "nightcams", "nightcamsbig", "indoorcams", "addcam"],
+        "unmutecam", "unmuteallcams", "nightcams", "nightcamsbig", "indoorcams", "addcam", "removecam"],
     commandOperator: [],
-    commandVips: ["getvolume", "setvolume", "resetvolume", "removecam", "swapcam", "scenecams", "mutecam", "muteallcams", "musicvolume", "musicnext", "musicprev", "mutemusic", "unmutemusic", "mutemusiclocal", "unmutemusiclocal", "resetbackpack", "resetpc", "resetlivecam", "resetbackpackf", "resetpcf", "resetlivecamf", "resetcam", "resetextra","resetphone", "resetphonef"],
+    commandVips: ["getvolume", "setvolume", "resetvolume", "swapcam", "scenecams", "mutecam", "muteallcams", "musicvolume", "musicnext", "musicprev", "mutemusic", "unmutemusic", "mutemusiclocal", "unmutemusiclocal", "resetbackpack", "resetpc", "resetlivecam", "resetbackpackf", "resetpcf", "resetlivecamf", "resetcam", "resetextra","resetphone", "resetphonef"],
     commandUsers: []
 }
 timeRestrictedCommands = timeRestrictedCommands.concat(["unmutecam", "unmuteallcams"]);

--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -418,20 +418,20 @@ function checkTimeAccess(controller, userCommand, accessProfile, channel, messag
 			hasAccess = true;
 		}
 		//not directly allowed
-		if (!hasAccess) {
-			//check time
-			let now = new Date();
-			// var minutes = now.getUTCMinutes();
-			var hour = now.getUTCHours();
-			// console.log("check time",now,hour,config.restrictedHours);
-			if (hour >= config.restrictedHours.start && hour < config.restrictedHours.end) {
-				//restricted time
-				hasAccess = false;
-			} else {
-				//allow access to mods
-				hasAccess = true;
-			}
-		}
+		// if (!hasAccess) {
+		// 	//check time
+		// 	let now = new Date();
+		// 	// var minutes = now.getUTCMinutes();
+		// 	var hour = now.getUTCHours();
+		// 	// console.log("check time",now,hour,config.restrictedHours);
+		// 	if (hour >= config.restrictedHours.start && hour < config.restrictedHours.end) {
+		// 		//restricted time
+		// 		hasAccess = false;
+		// 	} else {
+		// 		//allow access to mods
+		// 		hasAccess = true;
+		// 	}
+		// }
 	} else {
 		hasAccess = true;
 	}
@@ -1654,6 +1654,8 @@ async function checkExtraCommand(controller, userCommand, accessProfile, channel
 						camName = overrideArgs;
 					}
 
+
+					controller.connections.database[camName].blacklist = true;
 					//camName = "fullcam"+camName;
 
 					//remove cam
@@ -2177,9 +2179,11 @@ async function switchToCustomCams(controller, channel, accessProfile, userComman
 			//Admin
 			if (config.userPermissions.commandPriority[0] == accessProfile.accessLevel) {
 				hasAccess = true;
+				controller.connections.database[camName].blacklist = false;
 				//Superuser
 			} else if (config.userPermissions.commandPriority[1] == accessProfile.accessLevel) {
 				hasAccess = true;
+				controller.connections.database[camName].blacklist = false;
 				//Mod
 			} else if (!config.timeRestrictedScenes.includes(camName)) {
 				logger.log("Reached Regular Access", "Non time restricted", camName);
@@ -2189,7 +2193,12 @@ async function switchToCustomCams(controller, channel, accessProfile, userComman
 				//not directly allowed
 				//check if allowed access to cam
 				//specific mod time restrictions
-				if (config.timeRestrictedScenes.includes(camName)) {
+				if (controller.connections.database[camName].blacklist == true){
+					// Cam is blacklisted and can't be swapped too
+					hasAccess = false;
+					break;
+				}
+				else if (config.timeRestrictedScenes.includes(camName) && controller.connections.database.timeRestrictionDisabled == true) {
 					//check time
 					let now = new Date();
 					var minutes = now.getUTCMinutes();

--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -2198,7 +2198,7 @@ async function switchToCustomCams(controller, channel, accessProfile, userComman
 					hasAccess = false;
 					break;
 				}
-				else if (config.timeRestrictedScenes.includes(camName) && controller.connections.database.timeRestrictionDisabled == true) {
+				else if (config.timeRestrictedScenes.includes(camName) && controller.connections.database.timeRestrictionDisabled == false) {
 					//check time
 					let now = new Date();
 					var minutes = now.getUTCMinutes();


### PR DESCRIPTION
!removecam [camname] now blacklists the camera, only superuser or higher can add them back