### PR TITLE
Add ptzgetspeed command

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -244,7 +244,7 @@ const commandPermissionsCamera = {
     commandMods: ["testmodcamera", "ptztracking", "ptzirlight", "ptzwake"],
     commandOperator: ["ptzhomeold","ptzseta","ptzgetinfo","ptzset", "ptzpan", "ptztilt", "ptzmove", "ptzir", "ptzdry",
                      "ptzfov", "ptzstop", "ptzsave", "ptzremove", "ptzrename", "ptzcenter", "ptzareazoom", "ptzclick", "ptzdraw",
-                     "ptzspeed", "ptzspin", "ptzcfocus"],
+                     "ptzspeed", "ptzgetspeed", "ptzspin", "ptzcfocus"],
     commandVips: ["ptzhome", "ptzpreset", "ptzzoom","ptzzoomr", "ptzload", "ptzlist", "ptzroam", "ptzroaminfo", "ptzfocus", "ptzgetfocus", "ptzfocusr", "ptzautofocus", "ptzgetcam"],
     commandUsers: []
 }

--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -695,9 +695,6 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 				camera.continuousFocus(0);
 			}
 			break;
-		case "ptzcfocus":
-			camera.continuousFocus(arg1);
-			break;
 		case "ptzautofocus":
 			if (arg1 == "1" || arg1 == "on" || arg1 == "yes") {
 				camera.enableAutoFocus();
@@ -735,6 +732,10 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 		case "ptzspeed":
 			camera.setSpeed(arg1);
 			controller.connections.database[currentScene].speed = arg1;
+			break;
+		case "ptzgetspeed":
+			let camSpeed = await camera.getSpeed();
+			controller.connections.twitch.send(channel, `PTZ Speed: ${camSpeed}`)
 			break;
 		case "ptzcenter":
 			//x-cord y-cord rzoom 


### PR DESCRIPTION
Adding a way to check the current speed of a cam, ptzspeed has been available to set the speed but there wasn't a way to check the current speed.