### PR TITLE
Add parent map for new multicams

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -112,8 +112,10 @@ let multiCommands = {
 //Scene Names in OBS
 //lowercase, no spaces, no s/es
 const multiScenes = {
-    crow: ["crow", "crowoutdoor", "crowmulticam", "crowmulti2cam"],
-    wolf: ["wolf", "wolfcorner","wolfindoor","wolfden","wolfden2","wolfmulti","wolfmulti2","wolfmulti3","wolfmulti4","wolfmulti5"],
+    crow: ["crow", "crowoutdoor", "crowmulti2cam"],
+    crowoutdoor: ["crowmulticam"],
+    wolf: ["wolf", "wolfcorner","wolfindoor","wolfden","wolfden2","wolfmulti","wolfmulti2","wolfmulti3","wolfmulti4"],
+    wolfcorner: ["wolfmulti5"],
     fox: ["fox", "foxden", "foxmulticam", "foxcorner"],
     marmoset: ["marmoset", "marmosetindoor", "marmosetmulti"],
     // rat: ["ratcam","ratcam2","ratcam3","ratcam4"]


### PR DESCRIPTION
Currently the config.multiscene maps all crow multiscenes to parent "crow" and all wolf multi scenes to parent "wolf". 

With "crowmulti", crowoutdoor is the parent so the map to crow causes clicking on the main cam to move the pip, with wolfcwolfin (wolfmulti5) where the parent cam is wolfcorner not wolf, clicking doesnt work at all as it tries to send the click to wolf

Added new maps to config.multiScenes for these two multi cams.
 
