### PR TITLE
Update ptzspeed command

### DIFF
--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -730,8 +730,13 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 			camera.enableAutoFocus();
 			break;
 		case "ptzspeed":
-			camera.setSpeed(arg1);
-			controller.connections.database[currentScene].speed = arg1;
+			if (arg1 != "") {
+				camera.setSpeed(arg1);
+				controller.connections.database[currentScene].speed = arg1;
+			} else {
+				let camSpeed = await camera.getSpeed();
+				controller.connections.twitch.send(channel, `PTZ Speed: ${camSpeed}`)
+			}
 			break;
 		case "ptzgetspeed":
 			let camSpeed = await camera.getSpeed();


### PR DESCRIPTION
Add a conditional statement to the !ptzspeed command to avoid setting speed to 1 when no value is provided.

Previous functionality would set cam speed to the lowest possible value (1) if no argument was provided, this should now return the current speed if no value is provided and otherwise set the speed to the provided value.

I haven't tested this code, but it should be pretty straightforward.