### PR TITLE
Add getcam to null camera check bypass

### DIFF
--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -629,7 +629,7 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 	}
 
 	//cant find camera client
-	if (camera == null && !(userCommand.includes("ptzdraw") || userCommand.includes("ptzclick"))) {
+	if (camera == null && !(userCommand.includes("ptzdraw") || userCommand.includes("ptzclick") || userCommand.includes("ptzgetcam"))) {
 		return false;
 	}
 


### PR DESCRIPTION
Lets getcam skip the null cam check so that it still works when a non-ptz cam is in the main slot