### PR TITLE
Add optional autofocus arg to ptzclick and ptzdraw

### DIFF
--- a/src/modules/legacy.js
+++ b/src/modules/legacy.js
@@ -785,7 +785,9 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 			// Set the camera
 			camera = controller.connections.cameras[clickbox.ptzcamName];
 			await camera.ptz({ areazoom: `${Math.round(clickbox.x)},${Math.round(clickbox.y)},${Math.round(zoom)}` });
-			await camera.enableAutoFocus();
+			if (arg4 != 'off') {
+				await camera.enableAutoFocus();
+			}
 			controller.connections.twitch.send(channel, `Clicked on ${clickbox.zone + 1}: ${clickbox.ptzcamName}`);
 			break;
 		case "ptzdraw":
@@ -809,26 +811,14 @@ async function checkPTZCommand(controller, userCommand, accessProfile, channel, 
 			let zoomWidth = drawbox.sourceWidth / scaledRectWidth;
 			let zoomHeight = drawbox.sourceHeight / scaledRectHeight;
 
-			zoom = Math.min(zoomWidth, zoomHeight);
-			// Optional argument that will cause zoom to be reduced at high zoom levels
-			if (arg5 != "") {
-				let cutOff = parseFloat(arg4, 10);
-				if (isNaN(cutOff)) {
-					return;
-				}
-				if (zoom < cutOff) {
-					zoom = zoom * 75;
-				} else {
-					zoom = zoom * 100;
-				}
-			} else {
-				zoom = zoom * 100;
-			}
+			zoom = Math.min(zoomWidth, zoomHeight) * 100;
 
 			// Set the camera
 			camera = controller.connections.cameras[drawbox.ptzcamName];
 			await camera.ptz({ areazoom: `${Math.round(drawbox.x)},${Math.round(drawbox.y)},${Math.round(zoom)}` });
-			await camera.enableAutoFocus();
+			if (arg5 != 'off') {
+				await camera.enableAutoFocus();
+			}
 			controller.connections.twitch.send(channel, `Clicked on ${drawbox.zone + 1}: ${drawbox.ptzcamName}`);
 			break;
 		case "ptzset":


### PR DESCRIPTION
Added optional argument to !ptzclick and !ptzdraw commands, this allows for the option to add "off" as the last argument to prevent autofocus from being enabled with the movement. In theory, this can help with moving cams when you want a specific focus level.

If no argument is provided (or any argument other than "off), the command will work as it currently works by running autofocus.

Also removed an optional zoom argument from !ptzdraw after talking with merger. Since it isn't used, it makes it much easier to implement the optional autofocus arg.